### PR TITLE
Several updates: - Removed statevarkeys from subsystems.  Each subsystem only gets its own keys assigned - Hence, the same key created for the state is used for the subsystem - These changes allow for setting statevarkeys after the constructor call so they no longer need to be defined in CanPerform() - small changes to the JSON input format - Subsystem parameters set in constructor - Had to tweak the scriptedSubsystem to make this all work.  Could maybe use a bit of review

### DIFF
--- a/samples/Aeolus/DSAC_Static_Mod.json
+++ b/samples/Aeolus/DSAC_Static_Mod.json
@@ -33,6 +33,13 @@
           {
             "type": "adcs",
             "name": "ADCS",
+            "parameters": [
+              {
+                "name": "slewRate",
+                "type": "double",
+                "value":  5
+              }
+            ],
             "states": [
               {
                 "type": "Matrix",
@@ -201,6 +208,13 @@
           {
             "type": "ADCS",
             "name": "ADCS",
+            "parameters": [
+              {
+                "name": "slewRate",
+                "type": "double",
+                "value": 5
+              }
+            ],
             "states": [
               {
                 "type": "Matrix",
@@ -457,27 +471,16 @@
     ],
     "evaluator": {
       "type": "TargetValueEvaluator",
-      "src": "..\\..\\..\\samples\\Aeolus\\pythonScripts\\eval.py",
       "className": "EVAL",
-      "keyRequests": [
+      "states": [
         {
           "asset": "Asset1",
-          "subsystem": "SSDR",
+          "key": "DataBufferFillRatio",
           "type": "double"
         },
         {
           "asset": "Asset2",
-          "subsystem": "SSDR",
-          "type": "double"
-        },
-        {
-          "asset": "Asset2",
-          "subsystem": "EOSensor",
-          "type": "double"
-        },
-        {
-          "asset": "Asset1",
-          "subsystem": "ADCS",
+          "key": "DataBufferFillRatio",
           "type": "double"
         }
       ]

--- a/samples/Aeolus/DSAC_Static_Scripted.json
+++ b/samples/Aeolus/DSAC_Static_Scripted.json
@@ -475,29 +475,26 @@
         "fcnName": "Power_asset1_from_SSDR_asset1"
       }
     ],
+    // evaluator node should be very similar to subsystem node
+    // should have stateVarKeys and parameters as inputs
+    //
+    // stateVarKey is an asset, key, and type
+    // Can verify with a Python helper that python implmented evaluator sets
+    // state and paramters as well as trying to set a state or paramters that does
+    // exisit in the python implementation
     "evaluator": {
       "type": "TargetValueEvaluator",
       "src": "..\\..\\..\\samples\\Aeolus\\pythonScripts\\eval.py",
       "className": "EVAL",
-      "keyRequests": [
+      "states": [
         {
           "asset": "Asset1",
-          "subsystem": "SSDR",
+          "key": "DataBufferFillRatio",
           "type": "double"
         },
         {
           "asset": "Asset2",
-          "subsystem": "SSDR",
-          "type": "double"
-        },
-        {
-          "asset": "Asset2",
-          "subsystem": "EOSensor",
-          "type": "double"
-        },
-        {
-          "asset": "Asset1",
-          "subsystem": "ADCS",
+          "key": "DataBufferFillRatio",
           "type": "double"
         }
       ]

--- a/src/HSFScheduler/Evaluator.cs
+++ b/src/HSFScheduler/Evaluator.cs
@@ -5,6 +5,7 @@ using System;
 using HSFSystem;
 using System.Collections.Generic;
 using Utilities;
+using Newtonsoft.Json.Linq;
 
 namespace HSFScheduler
 {

--- a/src/HSFScheduler/EvaluatorFactory.cs
+++ b/src/HSFScheduler/EvaluatorFactory.cs
@@ -12,41 +12,61 @@ using MissionElements;
 using Utilities;
 using Newtonsoft.Json.Linq;
 using UserModel;
+using System.CodeDom;
+using log4net;
 
 namespace HSFScheduler
 {
     public class EvaluatorFactory
     {
+        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        public static Evaluator GetEvaluator(JObject evaluatorJson, List<Subsystem> subsystemList)
+        public static Evaluator GetEvaluator(JObject evaluatorJson, SystemState initialSysState)
         {
             Evaluator schedEvaluator = null;
+            List<StateVariableKey<dynamic>> evaluatorStates = new List<StateVariableKey<dynamic>>();
 
-            if (JsonLoader<JToken>.TryGetValue("KeyRequests", evaluatorJson, out JToken keyRequests))
 
-                if (JsonLoader<string>.TryGetValue("Type", evaluatorJson, out string type))
+            string msg = "";
+
+            if (JsonLoader<string>.TryGetValue("type", evaluatorJson, out string evaluatorType))
+            {
+                if (JsonLoader<JToken>.TryGetValue("states", evaluatorJson, out JToken statesJson))
                 {
-                    if (type.Equals("scripted", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        List<dynamic> keychain = BuildKeyChain(keyRequests, subsystemList);
-                        schedEvaluator = new ScriptedEvaluator(evaluatorJson, keychain);
-                        Console.WriteLine("Scripted Evaluator Loaded");
-                    }
-                    else if (type.ToLower().Equals("TargetValueEvaluator", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        List<dynamic> keychain = BuildKeyChain(keyRequests, subsystemList);
-                        schedEvaluator = new TargetValueEvaluator(keychain);
-                        Console.WriteLine("Target Value Evaluator Loaded");
-                    }
-                    else
-                    {
-                        schedEvaluator = new DefaultEvaluator(); // ensures at least default is used
-                        Console.WriteLine("Default Evaluator Loaded...  This may cause problems...");
-                    }
                 }
                 else
                 {
-                    Console.WriteLine("Attempt to load evaluator failed, loading Default Evaluator...  This may cause problems...");
+                    msg = $"The Evaluator {evaluatorType} does not contain any stateKey requests.";
+                    Console.WriteLine(msg);
+                    log.Error(msg);
+                    throw new ArgumentOutOfRangeException(msg);
+                }
+
+                if (evaluatorType.Equals("scripted", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    //List<dynamic> keychain = BuildKeyChain(keyRequests, subsystemList);
+                    //schedEvaluator = new ScriptedEvaluator(keyRequests, initialSysState);
+                    Console.WriteLine("Scripted Evaluator Loaded");
+                }
+                else if (evaluatorType.ToLower().Equals("TargetValueEvaluator", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    //List<dynamic> keychain = BuildKeyChain(keyRequests, subsystemList);
+                    schedEvaluator = new TargetValueEvaluator(statesJson, initialSysState);
+                    Console.WriteLine("Target Value Evaluator Loaded");
+                }
+                else
+                {
+                    msg = $"Could not load the Evaluator of type {evaluatorType}.  Default Evaluator Loaded...  This may cause problems...";
+                    Console.WriteLine(msg);
+                    log.Error(msg);
+                    schedEvaluator = new DefaultEvaluator(); // ensures at least default is used
+                }
+            }
+            else
+            {
+                    msg = $"Could not load the Evaluator of type {evaluatorType}.  Default Evaluator Loaded...  This may cause problems...";
+                    Console.WriteLine(msg);
+                    log.Error(msg);
                     schedEvaluator = new DefaultEvaluator(); // ensures at least default is used
                 }
 
@@ -59,8 +79,8 @@ namespace HSFScheduler
 
             foreach (JObject key in keyRequests)
             {
-                JsonLoader<string>.TryGetValue("subsystem", key, out string InputSub);
-                InputSub = InputSub.ToLower();
+                JsonLoader<string>.TryGetValue("key", key, out string InputKey);
+                InputKey = InputKey.ToLower();
                 JsonLoader<string>.TryGetValue("asset", key, out string InputAsset);
                 InputAsset = InputAsset.ToLower();
                 JsonLoader<string>.TryGetValue("type", key, out string InputType);
@@ -69,60 +89,62 @@ namespace HSFScheduler
                 //string InputAsset = keySourceNode.Attributes["keyAsset"].Value.ToString().ToLower();
                 //string InputType = keySourceNode.Attributes["keyType"].Value.ToString().ToLower();
 
-                Subsystem subRequested = subsystems.Find(s => s.Name == InputAsset + "." + InputSub);
+                Subsystem subRequested = subsystems.Find(s => s.Name == InputAsset + "." + InputKey);
 
-                if (subRequested == null)
-                {
-                    Console.WriteLine("Asset/Subsystem pair requested was not found!");
-                    throw new ArgumentException("Asset/Subsystem pair requested was not found!");
-                }
-                if (InputType.Equals("int"))
-                {
-                    foreach (StateVariableKey<Int32> keyOfTypeRequested in subRequested.Ikeys)
-                    {
-                        keychain.Add(keyOfTypeRequested);
-                    }
-                }
-                else if (InputType.Equals("double"))
-                {
-                    foreach (StateVariableKey<double> keyOfTypeRequested in subRequested.Dkeys)
-                    {
-                        keychain.Add(keyOfTypeRequested);
-                    }
-                }
-                else if (InputType.Equals("bool"))
-                {
-                    foreach (StateVariableKey<bool> keyOfTypeRequested in subRequested.Bkeys)
-                    {
-                        keychain.Add(keyOfTypeRequested);
-                    }
-                }
-                else if (InputType.Equals("matrix"))
-                {
-                    foreach (StateVariableKey<Matrix<double>> keyOfTypeRequested in subRequested.Mkeys)
-                    {
-                        keychain.Add(keyOfTypeRequested);
-                    }
-                }
-                else if (InputType.Equals("quat"))
-                {
-                    foreach (StateVariableKey<Quaternion> keyOfTypeRequested in subRequested.Qkeys)
-                    {
-                        keychain.Add(keyOfTypeRequested);
-                    }
-                }
-                else if (InputType.Equals("vector"))
-                {
-                    foreach (StateVariableKey<Vector> keyOfTypeRequested in subRequested.Vkeys)
-                    {
-                        keychain.Add(keyOfTypeRequested);
-                    }
-                }
-                else
-                {
-                    Console.WriteLine("Key type requested is not supported!");
-                    throw new ArgumentException("Key type requested is not supported!");
-                }
+                StateVariableKey<dynamic> newKey = new StateVariableKey<dynamic>(InputAsset + "." + InputKey);
+                keychain.Add(newKey);
+                //if (subRequested == null)
+                //{
+                //    Console.WriteLine("Asset/Subsystem pair requested was not found!");
+                //    throw new ArgumentException("Asset/Subsystem pair requested was not found!");
+                //}
+                //if (InputType.Equals("int"))
+                //{
+                //    foreach (StateVariableKey<Int32> keyOfTypeRequested in subRequested.Ikeys)
+                //    {
+                //        keychain.Add(keyOfTypeRequested);
+                //    }
+                //}
+                //else if (InputType.Equals("double"))
+                //{
+                //    foreach (StateVariableKey<double> keyOfTypeRequested in subRequested.Dkeys)
+                //    {
+                //        keychain.Add(keyOfTypeRequested);
+                //    }
+                //}
+                //else if (InputType.Equals("bool"))
+                //{
+                //    foreach (StateVariableKey<bool> keyOfTypeRequested in subRequested.Bkeys)
+                //    {
+                //        keychain.Add(keyOfTypeRequested);
+                //    }
+                //}
+                //else if (InputType.Equals("matrix"))
+                //{
+                //    foreach (StateVariableKey<Matrix<double>> keyOfTypeRequested in subRequested.Mkeys)
+                //    {
+                //        keychain.Add(keyOfTypeRequested);
+                //    }
+                //}
+                //else if (InputType.Equals("quat"))
+                //{
+                //    foreach (StateVariableKey<Quaternion> keyOfTypeRequested in subRequested.Qkeys)
+                //    {
+                //        keychain.Add(keyOfTypeRequested);
+                //    }
+                //}
+                //else if (InputType.Equals("vector"))
+                //{
+                //    foreach (StateVariableKey<Vector> keyOfTypeRequested in subRequested.Vkeys)
+                //    {
+                //        keychain.Add(keyOfTypeRequested);
+                //    }
+                //}
+                //else
+                //{
+                //    Console.WriteLine("Key type requested is not supported!");
+                //    throw new ArgumentException("Key type requested is not supported!");
+                //}
             }
             return keychain;
         }

--- a/src/HSFScheduler/SystemSchedule.cs
+++ b/src/HSFScheduler/SystemSchedule.cs
@@ -184,7 +184,7 @@ namespace HSFScheduler
             var csv = new StringBuilder();
             Dictionary<StateVariableKey<double>, SortedList<double, double>> stateTimeDData = new Dictionary<StateVariableKey<double>, SortedList<double, double>>();
             Dictionary<StateVariableKey<int>, SortedList<double, int>> stateTimeIData = new Dictionary<StateVariableKey<int>, SortedList<double, int>>();
-            Dictionary<StateVariableKey<int>, SortedList<double, int>> stateTimeBData = new Dictionary<StateVariableKey<int>, SortedList<double, int>>(); // need 0s and 1 for matlab to read in csv
+            Dictionary<StateVariableKey<bool>, SortedList<double, bool>> stateTimeBData = new Dictionary<StateVariableKey<bool>, SortedList<double, bool>>(); // need 0s and 1 for matlab to read in csv
             Dictionary<StateVariableKey<Matrix<double>>, SortedList<double, Matrix<double>>> stateTimeMData = new Dictionary<StateVariableKey<Matrix<double>>, SortedList<double, Matrix<double>>>();
             Dictionary<StateVariableKey<Quaternion>, SortedList<double, Quaternion>> stateTimeQData = new Dictionary<StateVariableKey<Quaternion>, SortedList<double, Quaternion>>();
             string stateTimeData = "Time,";
@@ -227,12 +227,12 @@ namespace HSFScheduler
                     foreach (var data in kvpBoolProfile.Value.Data)
                         if (!stateTimeBData.ContainsKey(kvpBoolProfile.Key))
                         {
-                            var lt = new SortedList<double, int>();
-                            lt.Add(data.Key, (data.Value ? 1 : 0)); //convert to int for matlab to read in for csv
-                            stateTimeBData.Add((StateVariableKey<int>)kvpBoolProfile.Key, lt);
+                            var lt = new SortedList<double, bool>();
+                            lt.Add(data.Key, (data.Value)); //convert to int for matlab to read in for csv
+                            stateTimeBData.Add(kvpBoolProfile.Key, lt);
                         }
                         else if (!stateTimeBData[kvpBoolProfile.Key].ContainsKey(data.Key))
-                            stateTimeBData[(StateVariableKey<int>)kvpBoolProfile.Key].Add(data.Key, data.Value ? 1 : 0);
+                            stateTimeBData[kvpBoolProfile.Key].Add(data.Key, data.Value);
 
                 foreach (var kvpMatrixProfile in sysState.Mdata)
                     foreach (var data in kvpMatrixProfile.Value.Data)

--- a/src/HSFSystem/AccessSub.cs
+++ b/src/HSFSystem/AccessSub.cs
@@ -8,20 +8,19 @@ using HSFUniverse;
 using MissionElements;
 using Newtonsoft.Json.Linq;
 using Utilities;
+using static IronPython.Modules._ast;
 
 namespace HSFSystem
 {
     public class AccessSub : Subsystem
     {
-        public AccessSub(JObject accessJson) { }
-        /// <summary>
-        /// Constructor for the built in subsystem (cannot be scripted)
-        /// </summary>
-        /// <param name="subNode"></param>
-        /// <param name="asset"></param>
-        public AccessSub(XmlNode subNode)
+        public AccessSub(JObject accessJson, Asset asset):base(accessJson, asset) { }
+
+        public override void SetStateVariableKey(dynamic stateKey)
         {
-            //DefaultSubName = "AccessToTarget";
+            string msg = $"Warning: No StateVariableKeys set for subsystem {this.Name}";
+            Console.WriteLine(msg);
+            log.Warn(msg);
         }
 
         public override bool CanPerform(Event proposedEvent, Domain environment)

--- a/src/HSFSystem/Comm.cs
+++ b/src/HSFSystem/Comm.cs
@@ -12,7 +12,6 @@ using Utilities;
 
 namespace HSFSystem
 {
-    //[ExcludeFromCodeCoverage]
     public class Comm : Subsystem
     {
         #region Attributes
@@ -21,13 +20,22 @@ namespace HSFSystem
 
         #region Constructors
 
-        public Comm(JObject commJson)
+        public Comm(JObject commJson, Asset asset):base(commJson, asset)
         {
 
         }
         #endregion
 
         #region Methods
+
+        public override void SetStateVariableKey(dynamic stateKey)
+        {
+            if (stateKey.VariableName.Equals(Asset.Name + ".datarate(mb/s)"))
+                this.DATARATE_KEY = stateKey;
+            else
+                throw new ArgumentException("Attempting to set unknown Comm state variable key.", stateKey);
+        }
+
         /// <summary>
         /// An override of the Subsystem CanPerform method
         /// </summary>
@@ -36,14 +44,11 @@ namespace HSFSystem
         /// <returns></returns>
         public override bool CanPerform(Event proposedEvent, Domain environment)
         {
-            var DATARATE_KEY = Dkeys[0];
-
             if (Task.Type == "comm")
             {
                 HSFProfile<double> newProf = DependencyCollector(proposedEvent);
                 if (!newProf.Empty())
                     proposedEvent.State.AddValues(DATARATE_KEY, newProf);
-                //proposedEvent.State.SetProfile(DATARATE_KEY, newProf);
             }
             return true;
         }
@@ -55,7 +60,6 @@ namespace HSFSystem
         /// <returns></returns>
         public HSFProfile<double> Power_asset1_from_Comm_asset1(Event currentEvent)
         {
-            var DATARATE_KEY = Dkeys[0];
             return currentEvent.State.GetProfile(DATARATE_KEY) * 20;
         }
         #endregion

--- a/src/HSFSystem/IMU.cs
+++ b/src/HSFSystem/IMU.cs
@@ -45,65 +45,66 @@ namespace HSFSystem
         public IMU(XmlNode SubNode, Asset asset)
         {
 
-            Asset = asset;
-            GetSubNameFromXmlNode(SubNode);
-            int gyr = 0;
-            int acc = 1;
-            XmlNode IMUNode = SubNode;
-            if (SubNode.ChildNodes[1].Name.Equals("Gyro"))
-            {
-                gyr = 1;
-                acc = 0;
-            }
+            //Asset = asset;
+            //GetSubNameFromXmlNode(SubNode);
+            //int gyr = 0;
+            //int acc = 1;
+            //XmlNode IMUNode = SubNode;
+            //if (SubNode.ChildNodes[1].Name.Equals("Gyro"))
+            //{
+            //    gyr = 1;
+            //    acc = 0;
+            //}
 
-            if (IMUNode.ChildNodes[gyr].Attributes["gyroNaturalFrequency"] != null)
-                _gyrNaturalFrequency = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroNaturalFrequency"].Value.ToString(), typeof(double));
-            if (IMUNode.ChildNodes[gyr].Attributes["gyroDampingRatio"] != null)
-                _gyrDampingRatio = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroDampingRatio"].Value.ToString(), typeof(double));
-            if (IMUNode.ChildNodes[gyr].Attributes["gyroMax"] != null)
-                _gyrMax = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroMax"].Value.ToString(), typeof(double));
-            if (IMUNode.ChildNodes[gyr].Attributes["gyroMin"] != null)
-                _gyrMin = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroMin"].Value.ToString(), typeof(double));
-            if (IMUNode.ChildNodes[gyr].Attributes["gyroRateNoiseDensity"] != null)
-                _gyrRateNoiseDensity = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroRateNoiseDensity"].Value.ToString(), typeof(double));
-            if (IMUNode.ChildNodes[gyr].Attributes["gyroBias"] != null)
-                _gyrBias = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroBias"].Value.ToString(), typeof(double));
-            if (IMUNode.ChildNodes[gyr].Attributes["gyroOutputRate"] != null)
-                _gyrOutputRate = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroOutputRate"].Value.ToString(), typeof(double));
-            if (IMUNode.ChildNodes[gyr].Attributes["gyroOutputRate"] != null)
-                _gyrScaleFactor = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroScaleFactor"].Value.ToString(), typeof(double));
-            if (IMUNode.ChildNodes[gyr].Attributes["gyroOutputRate"] != null)
-                _gyrNonLinearity = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroNonLinearity"].Value.ToString(), typeof(double));
-            if (IMUNode.ChildNodes[gyr].Attributes["gyroOutputRate"] != null)
-                _gyrAccelSensitivity = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroAccelSensitivity"].Value.ToString(), typeof(double));
-            if (IMUNode.ChildNodes[gyr].Attributes["gyroOutputRate"] != null)
-                _gyrCrossAxis = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroCrossAxis"].Value.ToString(), typeof(double));
-            if (IMUNode.ChildNodes[acc].Attributes["accNoiseDensity"] != null)
-                _accNoiseDensity = (double)Convert.ChangeType(IMUNode.ChildNodes[acc].Attributes["accNoiseDensity"].Value.ToString(), typeof(double));
-            if (IMUNode.ChildNodes[acc].Attributes["accNaturalFrequency"] != null)
-                _accNaturalFrequency = (double)Convert.ChangeType(IMUNode.ChildNodes[acc].Attributes["accNaturalFrequency"].Value.ToString(), typeof(double));
-            if (IMUNode.ChildNodes[acc].Attributes["accDampingRatio"] != null)
-                _accDampingratio = (double)Convert.ChangeType(IMUNode.ChildNodes[acc].Attributes["accDampingRatio"].Value.ToString(), typeof(double));
-            if (IMUNode.ChildNodes[acc].Attributes["accMax"] != null)
-                _accMax = (double)Convert.ChangeType(IMUNode.ChildNodes[acc].Attributes["accMax"].Value.ToString(), typeof(double));
-            if (IMUNode.ChildNodes[acc].Attributes["accMin"] != null)
-                _accMin = (double)Convert.ChangeType(IMUNode.ChildNodes[acc].Attributes["accMin"].Value.ToString(), typeof(double));
-            if (IMUNode.ChildNodes[acc].Attributes["accOutputRate"] != null)
-                _accOutputRate = (double)Convert.ChangeType(IMUNode.ChildNodes[acc].Attributes["accOutputRate"].Value.ToString(), typeof(double));
-            if (IMUNode.ChildNodes[acc].Attributes["accNonLinearity"] != null)
-                _accNonLinearity = (double)Convert.ChangeType(IMUNode.ChildNodes[acc].Attributes["accNonLinearity"].Value.ToString(), typeof(double));
-            if (IMUNode.ChildNodes[acc].Attributes["accCrossAxis"] != null)
-                _accCrossAxis = (double)Convert.ChangeType(IMUNode.ChildNodes[acc].Attributes["accCrossAxis"].Value.ToString(), typeof(double));
-            if (IMUNode.ChildNodes[acc].Attributes["accScaleFactor"] != null)
-                _accScaleFactor = (double)Convert.ChangeType(IMUNode.ChildNodes[acc].Attributes["accScaleFactor"].Value.ToString(), typeof(double));
+            //if (IMUNode.ChildNodes[gyr].Attributes["gyroNaturalFrequency"] != null)
+            //    _gyrNaturalFrequency = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroNaturalFrequency"].Value.ToString(), typeof(double));
+            //if (IMUNode.ChildNodes[gyr].Attributes["gyroDampingRatio"] != null)
+            //    _gyrDampingRatio = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroDampingRatio"].Value.ToString(), typeof(double));
+            //if (IMUNode.ChildNodes[gyr].Attributes["gyroMax"] != null)
+            //    _gyrMax = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroMax"].Value.ToString(), typeof(double));
+            //if (IMUNode.ChildNodes[gyr].Attributes["gyroMin"] != null)
+            //    _gyrMin = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroMin"].Value.ToString(), typeof(double));
+            //if (IMUNode.ChildNodes[gyr].Attributes["gyroRateNoiseDensity"] != null)
+            //    _gyrRateNoiseDensity = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroRateNoiseDensity"].Value.ToString(), typeof(double));
+            //if (IMUNode.ChildNodes[gyr].Attributes["gyroBias"] != null)
+            //    _gyrBias = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroBias"].Value.ToString(), typeof(double));
+            //if (IMUNode.ChildNodes[gyr].Attributes["gyroOutputRate"] != null)
+            //    _gyrOutputRate = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroOutputRate"].Value.ToString(), typeof(double));
+            //if (IMUNode.ChildNodes[gyr].Attributes["gyroOutputRate"] != null)
+            //    _gyrScaleFactor = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroScaleFactor"].Value.ToString(), typeof(double));
+            //if (IMUNode.ChildNodes[gyr].Attributes["gyroOutputRate"] != null)
+            //    _gyrNonLinearity = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroNonLinearity"].Value.ToString(), typeof(double));
+            //if (IMUNode.ChildNodes[gyr].Attributes["gyroOutputRate"] != null)
+            //    _gyrAccelSensitivity = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroAccelSensitivity"].Value.ToString(), typeof(double));
+            //if (IMUNode.ChildNodes[gyr].Attributes["gyroOutputRate"] != null)
+            //    _gyrCrossAxis = (double)Convert.ChangeType(IMUNode.ChildNodes[gyr].Attributes["gyroCrossAxis"].Value.ToString(), typeof(double));
+            //if (IMUNode.ChildNodes[acc].Attributes["accNoiseDensity"] != null)
+            //    _accNoiseDensity = (double)Convert.ChangeType(IMUNode.ChildNodes[acc].Attributes["accNoiseDensity"].Value.ToString(), typeof(double));
+            //if (IMUNode.ChildNodes[acc].Attributes["accNaturalFrequency"] != null)
+            //    _accNaturalFrequency = (double)Convert.ChangeType(IMUNode.ChildNodes[acc].Attributes["accNaturalFrequency"].Value.ToString(), typeof(double));
+            //if (IMUNode.ChildNodes[acc].Attributes["accDampingRatio"] != null)
+            //    _accDampingratio = (double)Convert.ChangeType(IMUNode.ChildNodes[acc].Attributes["accDampingRatio"].Value.ToString(), typeof(double));
+            //if (IMUNode.ChildNodes[acc].Attributes["accMax"] != null)
+            //    _accMax = (double)Convert.ChangeType(IMUNode.ChildNodes[acc].Attributes["accMax"].Value.ToString(), typeof(double));
+            //if (IMUNode.ChildNodes[acc].Attributes["accMin"] != null)
+            //    _accMin = (double)Convert.ChangeType(IMUNode.ChildNodes[acc].Attributes["accMin"].Value.ToString(), typeof(double));
+            //if (IMUNode.ChildNodes[acc].Attributes["accOutputRate"] != null)
+            //    _accOutputRate = (double)Convert.ChangeType(IMUNode.ChildNodes[acc].Attributes["accOutputRate"].Value.ToString(), typeof(double));
+            //if (IMUNode.ChildNodes[acc].Attributes["accNonLinearity"] != null)
+            //    _accNonLinearity = (double)Convert.ChangeType(IMUNode.ChildNodes[acc].Attributes["accNonLinearity"].Value.ToString(), typeof(double));
+            //if (IMUNode.ChildNodes[acc].Attributes["accCrossAxis"] != null)
+            //    _accCrossAxis = (double)Convert.ChangeType(IMUNode.ChildNodes[acc].Attributes["accCrossAxis"].Value.ToString(), typeof(double));
+            //if (IMUNode.ChildNodes[acc].Attributes["accScaleFactor"] != null)
+            //    _accScaleFactor = (double)Convert.ChangeType(IMUNode.ChildNodes[acc].Attributes["accScaleFactor"].Value.ToString(), typeof(double));
 
         }
-        //public IMU(XmlNode SubNode ,Asset asset) : this(SubNode, asset)
-        //{
 
-        //}
         #endregion
         #region Overrides
+        public override void SetStateVariableKey(dynamic stateKey)
+        {
+            throw new NotImplementedException();
+        }
         /// <summary>
         /// An override of the Subsystem CanPerform method
         /// </summary>

--- a/src/HSFSystem/ScriptedSubsystem.cs
+++ b/src/HSFSystem/ScriptedSubsystem.cs
@@ -13,6 +13,7 @@ using System.Reflection;
 using Utilities;
 using System.Security.Cryptography.X509Certificates;
 using Newtonsoft.Json.Linq;
+using System.Security.Permissions;
 
 namespace HSFSystem
 {
@@ -23,6 +24,18 @@ namespace HSFSystem
         protected dynamic _pythonInstance;
 
         // Overide the accessors in order to modify the python instance
+
+        public override String Type
+        {
+            get { return _pythonInstance.Type; }
+            set { _pythonInstance.Type = value; }
+        }
+
+        public override Asset Asset
+        {
+            get { return _pythonInstance.Asset; }
+            set { _pythonInstance.Asset = value; }
+        }
         public override List<Subsystem> DependentSubsystems
         {
             get { return (List<Subsystem>)_pythonInstance.DependentSubsystems; }
@@ -35,11 +48,11 @@ namespace HSFSystem
             set { _pythonInstance.SubsystemDependencyFunctions = (Dictionary<string, Delegate>)value; }
         }
 
-        //public override bool IsEvaluated
-        //{
-        //    get { return (bool)_pythonInstance.IsEvaluated; }
-        //    set { _pythonInstance.IsEvaluated = (bool)value; }
-        //}
+        public override string Name
+        {
+            get { return (string)_pythonInstance.Name; }
+            set { _pythonInstance.Name = (string)value; }
+        }
 
         public override SystemState NewState
         {
@@ -68,15 +81,6 @@ namespace HSFSystem
         {
             StringComparison stringCompare = StringComparison.CurrentCultureIgnoreCase;
 
-            this.Asset = asset;
-            //if(scriptedSubsystemJson.TryGetValue("name", stringCompare, out JToken nameJason))
-            //    this.Name = this.Asset.Name.ToLower() + "." + nameJason.ToString().ToLower();
-            //else
-            //{
-            //    Console.WriteLine($"Error loading subsytem of type {this.Type}, missing Name attribute");
-            //    throw new ArgumentException($"Error loading subsytem of type {this.Type}, missing Name attribute\"");
-            //}
-
             if (scriptedSubsystemJson.TryGetValue("src", stringCompare, out JToken srcJason))
             {
                 this.src = srcJason.ToString();
@@ -96,7 +100,38 @@ namespace HSFSystem
                 throw new ArgumentException($"Error loading subsytem of type {this.Type}, missing ClassName attribute");
             }
 
+            // What needs to be part of the python instance and what is part of the C# get/set?
             InitSubsystem(scriptedSubsystemJson);
+
+            Delegate depCollector = _pythonInstance.GetDependencyCollector();
+            this.SubsystemDependencyFunctions = new Dictionary<string, Delegate>
+            {
+                { "DepCollector", depCollector }
+            };
+
+            this.Asset = asset;
+            string msg;
+            if (JsonLoader<string>.TryGetValue("name", scriptedSubsystemJson, out string name))
+                this.Name = asset.Name + "." + name.ToLower();
+            else
+            {
+                msg = $"Missing a subsystem 'name' attribute for subsystem in {asset.Name}, {this.Name}";
+                Console.WriteLine(msg);
+                log.Error(msg);
+                throw new ArgumentOutOfRangeException(msg);
+            }
+
+            if (JsonLoader<string>.TryGetValue("type", scriptedSubsystemJson, out string type))
+                this.Type = type.ToLower();
+            else
+            {
+                msg = $"Missing a subsystem 'type' attribute for subsystem in {asset.Name}, {this.Name}";
+                Console.WriteLine(msg);
+                log.Error(msg);
+                throw new ArgumentOutOfRangeException(msg);
+            }
+
+            this.DependentSubsystems = new List<Subsystem>();
         }
 
         private void InitSubsystem(params object[] parameters)
@@ -115,24 +150,20 @@ namespace HSFSystem
             p.Add(@"C:\Python310\Lib");
 
             engine.SetSearchPaths(p);
-            engine.ExecuteFile(src, scope);
+            engine.ExecuteFile(this.src, scope);
             var pythonType = scope.GetVariable(className);
             // Look into this, string matters - related to file name, I think
             _pythonInstance = ops.CreateInstance(pythonType);//, parameters);
-            Delegate depCollector = _pythonInstance.GetDependencyCollector();
-            SubsystemDependencyFunctions = new Dictionary<string, Delegate>
-            {
-                { "DepCollector", depCollector }
-            };
 
-            _pythonInstance.Asset = this.Asset;
-            _pythonInstance.Name = this.Name;
-            DependentSubsystems = new List<Subsystem>();
         }
         #endregion
 
         #region Methods
-
+        //NEED TO FIX THIS...
+        public override void SetStateVariableKey( dynamic stateKey)
+        {
+            throw new NotImplementedException();
+        }
         public void SetStateVariable<T>(ScriptedSubsystemHelper HSFHelper, string StateName, StateVariableKey<T> key)
         {
             HSFHelper.PythonInstance.SetStateVariable(_pythonInstance, StateName, key);
@@ -146,20 +177,6 @@ namespace HSFSystem
 
         public override bool CanPerform(Event proposedEvent, Domain environment)
         {
-            //if (IsEvaluated)
-            //    return true;
-
-            //// Check all dependent subsystems
-            //foreach (var sub in DependentSubsystems)
-            //{
-            //    if (!sub.IsEvaluated)
-            //        if (sub.CanPerform(proposedEvent, environment) == false)
-            //            return false;
-            //}
-
-            //_task = proposedEvent.GetAssetTask(Asset); //Find the correct task for the subsystem
-            //_newState = proposedEvent.State;
-            //IsEvaluated = true;
 
             // Call the can perform method that is in the python class
             bool perform = false;

--- a/src/HSFSystem/SubTest.cs
+++ b/src/HSFSystem/SubTest.cs
@@ -19,7 +19,7 @@ namespace HSFSystem
         #endregion
 
         #region Constructors
-        public SubTest(JObject subtestJson)
+        public SubTest(JObject subtestJson, Asset asset) : base(subtestJson, asset)
         {
             lookup = getList();
         }
@@ -27,6 +27,10 @@ namespace HSFSystem
         #endregion Constructors
 
         #region Methods
+        public override void SetStateVariableKey(dynamic stateKey)
+        {
+            throw new NotImplementedException();
+        }
         public override bool CanPerform(Event proposedEvent, Domain environment)
         {
             double es = proposedEvent.GetEventStart(Asset);

--- a/src/HSFSystem/Subsystem.cs
+++ b/src/HSFSystem/Subsystem.cs
@@ -8,6 +8,10 @@ using HSFUniverse;
 using MissionElements;
 using System.Xml;
 using System.Runtime.CompilerServices;
+using log4net;
+using Newtonsoft.Json.Linq;
+using UserModel;
+using System.Reflection.PortableExecutable;
 
 namespace HSFSystem
 {
@@ -15,20 +19,14 @@ namespace HSFSystem
     public abstract class Subsystem
     {
         #region Attributes
-        //public virtual bool IsEvaluated { get; set; }
-        public String Type { get; set; }
+
+        protected static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        public virtual String Type { get; set; }
         public bool IsEvaluated { get; set; }
-        public Asset Asset { get; set; }
+        public virtual Asset Asset { get; set; }
         public virtual List<Subsystem> DependentSubsystems { get; set; } = new List<Subsystem>();
-        public string Name { get; set; }
-        //public static string DefaultSubName { get; protected set; }
+        public virtual string Name { get; set; }
         public virtual Dictionary<string, Delegate> SubsystemDependencyFunctions { get; set; }
-        public List<StateVariableKey<int>> Ikeys { get; private set; } = new List<StateVariableKey<int>>();
-        public List<StateVariableKey<double>> Dkeys { get; protected set; } = new List<StateVariableKey<double>>();
-        public List<StateVariableKey<bool>> Bkeys { get; protected set; } = new List<StateVariableKey<bool>>();
-        public List<StateVariableKey<Matrix<double>>> Mkeys { get; protected set; } = new List<StateVariableKey<Matrix<double>>>();
-        public List<StateVariableKey<Quaternion>> Qkeys { get; protected set; } = new List<StateVariableKey<Quaternion>>();
-        public List<StateVariableKey<Vector>> Vkeys { get; protected set; } = new List<StateVariableKey<Vector>>();
         public virtual SystemState NewState { get; set; }
         public virtual MissionElements.Task Task { get; set; }
         #endregion Attributes
@@ -38,17 +36,33 @@ namespace HSFSystem
         {
 
         }
-        public Subsystem(string name)
+        public Subsystem(JObject subsystemJson, Asset asset)
         {
-            Name = name;
-        }
-        public Subsystem(XmlNode xmlNode, Asset asset)
-        {
+            string msg;
+            if (JsonLoader<string>.TryGetValue("name", subsystemJson, out string name))
+                this.Name = asset.Name + "." + name.ToLower();
+            else
+            {
+                msg = $"Missing a subsystem 'name' attribute for subsystem in {asset.Name}, {this.Name}";
+                Console.WriteLine(msg);
+                log.Error(msg);
+                throw new ArgumentOutOfRangeException(msg);
+            }
 
-        }
-        public Subsystem(XmlNode xmlNode, Dependency deps, Asset asset)
-        {
+            if (JsonLoader<string>.TryGetValue("type", subsystemJson, out string type))
+                this.Type = type.ToLower();
+            else
+            {
+                msg = $"Missing a subsystem 'type' attribute for subsystem in {asset.Name}, {this.Name}";
+                Console.WriteLine(msg);
+                log.Error(msg);
+                throw new ArgumentOutOfRangeException(msg);
+            }
 
+            this.Asset = asset;
+            this.DependentSubsystems = new List<Subsystem>();
+            this.SubsystemDependencyFunctions = new Dictionary<string, Delegate>();
+            this.AddDependencyCollector();
         }
         #endregion
 
@@ -58,17 +72,17 @@ namespace HSFSystem
             return DeepCopy.Copy<Subsystem>(this);
         }
 
+        public abstract void SetStateVariableKey(dynamic stateKey);
+
         /// <summary>
         /// The default canPerform method. 
         /// Should be used to check if all dependent subsystems can perform and extended by subsystem implementations.
         /// </summary>
-        /// <param name="oldState"></param>
-        /// <param name="newState"></param>
-        /// <param name="tasks"></param>
+        /// <param name="proposedEvent"></param>
         /// <param name="environment"></param>
         /// <returns></returns>
-        public virtual bool CanPerform(Event proposedEvent, Domain environment)
-        {
+        public abstract bool CanPerform(Event proposedEvent, Domain environment);
+        //{
             //foreach (var sub in DependentSubsystems)
             //{
             //    if (!sub.IsEvaluated)// && !sub.GetType().Equals(typeof(ScriptedSubsystem)))
@@ -78,8 +92,8 @@ namespace HSFSystem
             //_task = proposedEvent.GetAssetTask(Asset); //Find the correct task for the subsystem
             //_newState = proposedEvent.State;
             //IsEvaluated = true;
-            return true;
-        }
+            //return true;
+        //}
         /// <summary>
         /// This method tracks four things:
         /// 1.  Ensure all dependents Subsystems are evaluated before the current Subsystem is evaluates and set the
@@ -172,10 +186,6 @@ namespace HSFSystem
         /// <returns></returns>
         public virtual HSFProfile<double> DependencyCollector(Event currentEvent)
         {
-            if (this.Name != "asset1.power" & this.Name != "asset2.power" & this.Name != "asset1.ssdr" & this.Name != "asset2.ssdr" & this.Name != "asset1.comm" & this.Name != "asset2.comm")
-            { // Manually ensuring all subs that call DependencyCollector only have dep fns that return doubles
-
-            }
             if (SubsystemDependencyFunctions.Count == 0)
                 throw new MissingMemberException("You may not call the dependency collector in your can perform because you have not specified any dependency functions for " + Name);
             HSFProfile<double> outProf = new HSFProfile<double>();
@@ -191,148 +201,31 @@ namespace HSFSystem
             return outProf;
         }
 
-        /// <summary>
-        /// Find the subsystem name field from the XMLnode and create the name of format "Asset#.SubName
-        /// </summary>
-        /// <param name="subXmlNode"></param>
-        public void GetSubNameFromXmlNode(XmlNode subXmlNode)
+
+        public void GetParameterByName<T>(JObject subsysJson, string name, out T variable)
         {
-            string assetName = Asset.Name;
-            if (subXmlNode.Attributes["subsystemName"] != null)
-                Name = assetName + "." + subXmlNode.Attributes["subsystemName"].Value.ToString().ToLower();
-            //else if (DefaultSubName != null)
-            //    Name = assetName + "." + DefaultSubName.ToLower() ;
-            //else if (subXmlNode.Attributes["type"] != null)
-            //    Name = assetName + "." + subXmlNode.Attributes["type"].Value.ToString().ToLower();
-            else
-                throw new ArgumentException($"Missing a subsystem name attribute for subsystem in {assetName}!");
-        }
+            variable = default;
 
-        /// <summary>
-        /// Method to get subsystem name from xml node.
-        /// </summary>
-        /// <param name="subXmlNode"></param>
-        /// <param name="assetName"></param>
-        /// <returns></returns>
-        public static string parseNameFromXmlNode(XmlNode subXmlNode, string assetName)
-        {
-
-            string Name;
-            if (subXmlNode.Attributes["subsystemName"] != null)
-                Name = assetName + "." + subXmlNode.Attributes["subsystemName"].Value.ToString().ToLower();
-            //else if (DefaultSubName != null)
-            //    Name = assetName + "." + DefaultSubName.ToLower() ;
-            //else if (subXmlNode.Attributes["type"] != null)
-            //    Name = assetName + "." + subXmlNode.Attributes["type"].Value.ToString().ToLower();
-            else
-                throw new ArgumentException($"Missing a subsystem name attribute for subsystem in {assetName}!");
-            return Name;
-        }
-
-        //public void getInitialStateFromXmlNode(XmlNode ICXmlNode)
-        //{
-        //    Type keyType = Type.GetType(ICXmlNode.Attributes["type"].Value.ToString());
-        //    string key = ICXmlNode.Attributes["key"].Value.ToString();
-        //    string value = ICXmlNode.Attributes["value"].ToString();
-        //    if(keyType)
-        //    StateVarKey <keyType.GetType()> = new StateVarKey<keyType.GetType() > (key);
-        //    .ChangeType(value, keyType);
-        //}
-
-        /// <summary>
-        /// Method to get subsystem state at a given time. Should be used for writing out state data
-        /// </summary>
-        /// <param name="currentSystemState"></param>
-        /// <param name="time"></param>
-        /// <returns></returns>
-        public SystemState GetSubStateAtTime(SystemState currentSystemState, double time)
-        {
-            SystemState state = new SystemState();
-            foreach (var key in Ikeys)
+            if (JsonLoader<JArray>.TryGetValue("parameters", subsysJson, out JArray parameters))
             {
-                //state.AddValues(key, new HSFProfile<int>(time, currentSystemState.GetValueAtTime(key, time).Value));
-                state.Idata.Add(key, new HSFProfile<int>(time, currentSystemState.GetValueAtTime(key, time).Value));
+                foreach (JObject parameter in parameters)
+                {
+                    if (JsonLoader<string>.TryGetValue("name", parameter, out string varName))
+                    {
+                        if (varName == name)
+                        {
+                            JsonLoader<double>.TryGetValue("value", parameter, out  variable);;
+                        }
+                    }
+                    else
+                    {
+                        string msg = $"Missing the subsystem 'parameter' attribute, '{name}' for subsystem {this.Name}";
+                        Console.WriteLine(msg);
+                        log.Error(msg);
+                        throw new ArgumentOutOfRangeException(msg);
+                    }
+                }
             }
-            foreach (var key in Bkeys)
-            {
-                //state.AddValues(key, new HSFProfile<bool>(time, currentSystemState.GetValueAtTime(key, time).Value));
-                state.Bdata.Add(key, new HSFProfile<bool>(time, currentSystemState.GetValueAtTime(key, time).Value));
-            }
-            foreach (var key in Dkeys)
-            {
-                //state.AddValues(key, new HSFProfile<double>(time, currentSystemState.GetValueAtTime(key, time).Value));
-                state.Ddata.Add(key, new HSFProfile<double>(time, currentSystemState.GetValueAtTime(key, time).Value));
-            }
-            foreach (var key in Mkeys)
-            {
-                //state.AddValues(key, new HSFProfile<Matrix<double>>(time, currentSystemState.GetValueAtTime(key, time).Value));
-                state.Mdata.Add(key, new HSFProfile<Matrix<double>>(time, currentSystemState.GetValueAtTime(key, time).Value));
-            }
-            foreach (var key in Qkeys)
-            {
-                //state.AddValues(key, new HSFProfile<Quaternion>(time, currentSystemState.GetValueAtTime(key, time).Value));
-                state.Qdata.Add(key, new HSFProfile<Quaternion>(time, currentSystemState.GetValueAtTime(key, time).Value));
-            }
-            foreach (var key in Vkeys)
-            {
-                state.Vdata.Add(key, new HSFProfile<Vector>(time, currentSystemState.GetValueAtTime(key, time).Value));
-            }
-            return state;
-        }
-
-        // Add keys depending on the type of the key
-        public void addKey(StateVariableKey<int> keyIn)
-        {
-            if (Ikeys == null) //Only construct what you need
-            {
-                Ikeys = new List<StateVariableKey<int>>();
-            }
-            Ikeys.Add(keyIn);
-        }
-
-        public void addKey(StateVariableKey<double> keyIn)
-        {
-            if (Dkeys == null) //Only construct what you need
-            {
-                Dkeys = new List<StateVariableKey<double>>();
-            }
-            Dkeys.Add(keyIn);
-        }
-
-        public void addKey(StateVariableKey<bool> keyIn)
-        {
-            if (Bkeys == null) //Only construct what you need
-            {
-                Bkeys = new List<StateVariableKey<bool>>();
-            }
-            Bkeys.Add(keyIn);
-        }
-
-        public void addKey(StateVariableKey<Matrix<double>> keyIn)
-        {
-            if (Mkeys == null) //Only construct what you need
-            {
-                Mkeys = new List<StateVariableKey<Matrix<double>>>();
-            }
-            Mkeys.Add(keyIn);
-        }
-
-        public void addKey(StateVariableKey<Quaternion> keyIn)
-        {
-            if (Qkeys == null) //Only construct what you need
-            {
-                Qkeys = new List<StateVariableKey<Quaternion>>();
-            }
-            Qkeys.Add(keyIn);
-        }
-
-        public void addKey(StateVariableKey<Vector> keyIn)
-        {
-            if (Vkeys == null) //Only construct what you need
-            {
-                Vkeys = new List<StateVariableKey<Vector>>();
-            }
-            Vkeys.Add(keyIn);
         }
         #endregion
     }

--- a/src/Horizon/Program.cs
+++ b/src/Horizon/Program.cs
@@ -430,9 +430,9 @@ namespace Horizon
                                         foreach (JObject stateJson in stateListJson)
                                         {
                                             // Parse state node for key name and state type, add the key to the subsys's list of keys, return the key name
-                                            string keyName = SubsystemFactory.SetStateKeys(stateJson, subsys);
+                                            SubsystemFactory.SetInitialState(stateJson, subsys, InitialSysState);
                                             // Use key name and state type to set initial conditions 
-                                            InitialSysState.SetInitialSystemState(stateJson, keyName);
+                                            //InitialSysState.SetInitialSystemState(stateJson, stateVarKey);
                                         }
                                     }
                                     else
@@ -467,8 +467,10 @@ namespace Horizon
                             }
                             // Load Constraints
                             if (JsonLoader<JToken>.TryGetValue("constraints", assetJson, out JToken constraintListJson))
+                            {
                                 foreach (JObject constraintJson in constraintListJson)
                                     ConstraintsList.Add(ConstraintFactory.GetConstraint(constraintJson, SubList, asset.Name));
+                            }
                             else
                             {
                                 msg = $"Warning: Asset {asset.Name} loaded with no constraints";
@@ -532,10 +534,10 @@ namespace Horizon
             {
                 if (JsonLoader<JObject>.TryGetValue("Model", scenarioJson, out JObject modelJson))
                 {
-                    // Load Environment
+                    // Load Evaluator
                     if(JsonLoader<JObject>.TryGetValue("Evaluator", modelJson, out JObject evaluatorJson))
                     {
-                        SchedEvaluator = EvaluatorFactory.GetEvaluator(evaluatorJson, SubList);
+                        SchedEvaluator = EvaluatorFactory.GetEvaluator(evaluatorJson, InitialSysState);
                         Console.WriteLine("Evaluator Loaded");
                         log.Info("Evaluator Loaded");
                     }

--- a/src/MissionElements/SystemState.cs
+++ b/src/MissionElements/SystemState.cs
@@ -9,6 +9,7 @@ using Utilities;
 using System.Xml;
 using UserModel;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
 
 namespace MissionElements
 {
@@ -20,22 +21,22 @@ namespace MissionElements
         public SystemState PreviousState { get; set; } = null;
 
         /** The Dictionary of integer Profiles. */
-        public Dictionary<StateVariableKey<int>, HSFProfile<int>> Idata { get; private set; } = new Dictionary<StateVariableKey<int>, HSFProfile<int>>();
+        public Dictionary<StateVariableKey<int>, HSFProfile<int>> Idata { get; private set; } = [];
 
         /** The Dictionary of double precision Profiles. */
-        public Dictionary<StateVariableKey<double>, HSFProfile<double>> Ddata { get; private set; } = new Dictionary<StateVariableKey<double>, HSFProfile<double>>();
+        public Dictionary<StateVariableKey<double>, HSFProfile<double>> Ddata { get; private set; } = [];
 
         /** The Dictionary of boolean Profiles. */
-        public Dictionary<StateVariableKey<bool>, HSFProfile<bool>> Bdata { get; private set; } = new Dictionary<StateVariableKey<bool>, HSFProfile<bool>>();
+        public Dictionary<StateVariableKey<bool>, HSFProfile<bool>> Bdata { get; private set; } = [];
 
         /** The Dictionary of Matrix<double> Profiles. */
-        public Dictionary<StateVariableKey<Matrix<double>>, HSFProfile<Matrix<double>>> Mdata { get; private set; } = new Dictionary<StateVariableKey<Matrix<double>>, HSFProfile<Matrix<double>>>();
+        public Dictionary<StateVariableKey<Matrix<double>>, HSFProfile<Matrix<double>>> Mdata { get; private set; } = [];
 
         /** The Dictionary of Quaternion Profiles. */
-        public Dictionary<StateVariableKey<Quaternion>, HSFProfile<Quaternion>> Qdata { get; private set; } = new Dictionary<StateVariableKey<Quaternion>, HSFProfile<Quaternion>>();
+        public Dictionary<StateVariableKey<Quaternion>, HSFProfile<Quaternion>> Qdata { get; private set; } = [];
 
         /** The Dictionary of Vector Profiles. */
-        public Dictionary<StateVariableKey<Vector>, HSFProfile<Vector>> Vdata { get; private set; } = new Dictionary<StateVariableKey<Vector>, HSFProfile<Vector>>();
+        public Dictionary<StateVariableKey<Vector>, HSFProfile<Vector>> Vdata { get; private set; } = [];
 
         #endregion
 
@@ -75,7 +76,7 @@ namespace MissionElements
 
         #endregion
 
-        //TODO:  ONly used in unit testing
+        //TODO:  Only used in unit testing
         /// <summary>
         /// combine two system states by adding the states from one into the other
         /// </summary>
@@ -928,30 +929,25 @@ namespace MissionElements
         #endregion
 
 
-        public void SetInitialSystemState(JObject stateJson, string keyName)
+        public void SetInitialSystemState<T>(JToken intValueJson, StateVariableKey<T> stateVarKey)
         {
-            string type = "";
-
-            StringComparison stringCompare = StringComparison.CurrentCultureIgnoreCase;
-            if (stateJson.TryGetValue("Type", stringCompare, out JToken typeJson))
-                type = typeJson.Value<string>().ToLower();
+            Type keyType = typeof(T);
 
             double time = SimParameters.SimStartSeconds;
-
+        
             // Need to set state value based on state type
-            if (stateJson.TryGetValue("Value", stringCompare, out JToken valueJson))
-                if (type.Equals("int") || type.Equals("integer"))
-                    AddValue(new StateVariableKey<int>(keyName), time, valueJson.Value<int>());
-                else if (type.Equals("matrix"))
-                    AddValue(new StateVariableKey<Matrix<double>>(keyName), time, new Matrix<double>(valueJson.ToString()));
-                else if (type.Equals("double"))
-                    AddValue(new StateVariableKey<double>(keyName), time, valueJson.Value<double>());
-                else if (type.Equals("bool"))
-                    AddValue(new StateVariableKey<bool>(keyName), time, valueJson.Value<bool>());
-                else if (type.Equals("quaternion"))
-                    AddValue(new StateVariableKey<Quaternion>(keyName), time, new Quaternion(valueJson.ToString()));
-                else if (type.Equals("vector"))
-                    AddValue(new StateVariableKey<Vector>(keyName), time, new Vector(valueJson.ToString()));
+            if (keyType == typeof(int))
+                AddValue(stateVarKey, time, intValueJson.Value<int>());
+            else if (keyType == typeof(Matrix<double>))
+                AddValue(stateVarKey, time, new Matrix<double>(intValueJson.ToString()));
+            else if (keyType == typeof(double))
+                AddValue(stateVarKey, time, intValueJson.Value<double>());
+            else if (keyType == typeof(bool))
+                AddValue(stateVarKey, time, intValueJson.Value<bool>());
+            else if (keyType == typeof(Quaternion))
+                AddValue(stateVarKey, time, new Quaternion(intValueJson.ToString()));
+            else if (keyType == typeof(Vector))
+                AddValue(stateVarKey, time, new Vector(intValueJson.ToString()));
 
         }
     }

--- a/src/Utilities/StateVariableKey.cs
+++ b/src/Utilities/StateVariableKey.cs
@@ -42,7 +42,7 @@ namespace Utilities
             }
 
             StateVariableKey<T> p = obj as StateVariableKey<T>;
-            return VariableName.Equals(p.VariableName);
+            return this.GetKeyType() == p.GetKeyType() && VariableName.Equals(p.VariableName);
 
         }
 
@@ -92,6 +92,11 @@ namespace Utilities
         public StateVariableKey<T> DeepClone()
         {
             return new StateVariableKey<T>(VariableName);
+        }
+
+        public Type GetKeyType()
+        {
+            return typeof(T);
         }
         #endregion
     }


### PR DESCRIPTION

Removed statevarkeys from subsystems.  Each subsystem only gets its own keys assigned
- Hence, the same key created for the state is used for the subsystem
- These changes allow for setting statevarkeys after the constructor call so they no longer need to be defined in CanPerform()
- small changes to the JSON input format
- Subsystem parameters set in constructor
- Had to tweak the scriptedSubsystem to make this all work.  Could maybe use a bit of review

- Open question - can we get the statevarkeys defined in the constructor instead of the setstatevarkey function called by the factory?  This is an issue becuase of how the JSON file is set up and parsed.

- Open Question:  Is there an advantage to using a templated statevarkey?  Or should we just set the type to a string?